### PR TITLE
mudata 0.3.0 requires python>=3.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 57acfd7648337840b3dc3d12a561b5364cef24fe79d5f4b539b916a7c0e029a7
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -18,7 +18,7 @@ requirements:
   host:
     - flit-core
     - pip
-    - python >=3.9
+    - python >=3.10
     - hatchling
     - hatch-vcs
   run:
@@ -26,7 +26,7 @@ requirements:
     - h5py
     - numpy
     - pandas
-    - python >=3.9
+    - python >=3.10
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

mudata 0.3.0 requires python>=3.10 (https://github.com/scverse/mudata/commit/ce28ac42c941103f1d8521a5d805777d1af3651e), but the recent update PR (#12) didn't bump the minimum required python version. This results in mudata 0.3.0 being installed in python 3.9 conda envs. This PR fixes the minimum required python version. I'll also send a repodata patch to fix the existing 0.3.0 conda binary.

