### PR TITLE
Pin anndata <0.10.9 for mudata 0.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - hatchling
     - hatch-vcs
   run:
-    - anndata >=0.10.8
+    - anndata >=0.10.8,<0.10.9
     - h5py
     - numpy
     - pandas


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

My previous PR #13 to fix the Python pin passed the PR CI but then failed the CI for the merge commit, https://github.com/conda-forge/mudata-feedstock/commit/a0bbfa3329676b187ae61a4375276956e2a8f73e. This is because between opening the PR and merging the PR, anndata 0.10.9 was released (https://github.com/conda-forge/anndata-feedstock/pull/41), which broke mudata 0.3.0, s demonstrated below.

Note that I purposefully did *not* bump the build number. Since the CI failed after my last PR was merged, build number 1 was never uploaded.

```sh
mamba create --yes -n test-mudata-anndata \
  --override-channels -c conda-forge \
  python=3.10 mudata=0.3.0 anndata=0.10.8
mamba activate test-mudata-anndata

# No error with anndata 0.10.8
python -c "import mudata"

mamba install --yes \
  --override-channels -c conda-forge \
  anndata=0.10.9

# Failed import with anndata 0.10.9
 python -c "import mudata"
## Traceback (most recent call last):
##   File "<string>", line 1, in <module>
##   File "/home/wsl/mambaforge/envs/test-mudata-anndata/lib/python3.10/site-packages/mudata/__init__.py", line 17, in <module>
##     from ._core.io import (
##   File "/home/wsl/mambaforge/envs/test-mudata-anndata/lib/python3.10/site-packages/mudata/_core/io.py", line 23, in <module>
##     from .mudata import ModDict, MuData
##   File "/home/wsl/mambaforge/envs/test-mudata-anndata/lib/python3.10/site-packages/mudata/_core/mudata.py", line 18, in <module>
##     from anndata._core.aligned_mapping import (
## ImportError: cannot import name 'AlignedViewMixin' from 'anndata._core.aligned_mapping' (/home/wsl/mambaforge/envs/test-mudata-anndata/lib/python3.10/site-packages/anndata/_core/aligned_mapping.py)

mamba deactivate
```
